### PR TITLE
Added regex expression to handle date conversion

### DIFF
--- a/source/OFXSharp.Tests/OFXSharp.Tests.csproj
+++ b/source/OFXSharp.Tests/OFXSharp.Tests.csproj
@@ -45,6 +45,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="CanParser.cs" />
+    <Compile Include="OFXHelperMethodUnitTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
@@ -61,6 +62,9 @@
       <Project>{7bba813d-ee93-491a-b0c7-fbd588e393cb}</Project>
       <Name>OFXSharp</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/source/OFXSharp/OFXHelperMethods.cs
+++ b/source/OFXSharp/OFXHelperMethods.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Text.RegularExpressions;
 using System.Xml;
 
 namespace OFXSharp
@@ -23,24 +24,44 @@ namespace OFXSharp
         /// <returns>Date in format DDMMYYYY</returns>
         public static DateTime ToDate(this string date)
         {
-            try
-            {
-                if (date.Length < 8)
-                {
-                    return new DateTime();
-                }
+			try
+			{
+				string resultDate = null;
 
-                var dd = Int32.Parse(date.Substring(6, 2));
-                var mm = Int32.Parse(date.Substring(4, 2));
-                var yyyy = Int32.Parse(date.Substring(0, 4));
+				if (IsDateInOFXDefaultEspecification(date, out resultDate))
+				{
+					var dd = Int32.Parse(resultDate.Substring(6, 2));
+					var mm = Int32.Parse(resultDate.Substring(4, 2));
+					var yyyy = Int32.Parse(resultDate.Substring(0, 4));
 
-                return new DateTime(yyyy, mm, dd);
-            }
-            catch
-            {
-                throw new OFXParseException("Unable to parse date");
-            }
+					return new DateTime(yyyy, mm, dd);
+				}
+
+				return new DateTime();
+			}
+			catch
+			{
+				throw new OFXParseException("Unable to parse date");
+			}
         }
+
+		/// <summary>
+		/// Check if date this in YYYYMMDD format.
+		/// </summary>
+		/// <param name="date">String containing date.</param>
+		/// <returns>Returns true if format is valid.</returns>
+		public static bool IsDateInOFXDefaultEspecification(string date, out string result)
+		{
+			Regex regex = new Regex(@"^\d{4}((0\d)|(1[012]))(([012]\d)|3[01])");
+			bool isDateInOFXFormat = regex.IsMatch(date);
+
+			if (isDateInOFXFormat)
+				result = regex.Match(date).Value;
+			else
+				result = null;
+
+			return isDateInOFXFormat;
+		}
 
         /// <summary>
         /// Returns value of specified node


### PR DESCRIPTION
Some banks are sending date values as follows <DTSTART>20      </DTSTART> and this throw exception in the current implementation. I change to check date with regular expressions.
